### PR TITLE
Rather than highlight 'just' with colour use latex macroes.

### DIFF
--- a/katla.ipkg
+++ b/katla.ipkg
@@ -14,6 +14,7 @@ depends = idris2, contrib
 
 -- modules to install
 modules = Katla
+        , Data.SnocList
 
 -- main file (i.e. file to load at REPL)
 main = Katla

--- a/src/Data/SnocList.idr
+++ b/src/Data/SnocList.idr
@@ -1,0 +1,77 @@
+||| A Reversed List
+module Data.SnocList
+
+import Decidable.Equality
+import Data.List
+
+%default total
+
+public export
+data SnocList : (type : Type) -> Type where
+  Empty : SnocList type
+  Snoc  : SnocList type -> type -> SnocList type
+
+%name SnocList sx, sy, sz
+
+||| Reverse the list and make a list.
+public export
+toList : SnocList type -> List type
+toList Empty = Nil
+toList (Snoc sx x) = x :: toList sx
+
+||| Transform to a list but keeping the contents in the 'correct' order.
+public export
+asList : SnocList type -> List type
+asList = (reverse . toList)
+
+
+public export
+Eq a => Eq (SnocList a) where
+  (==) Empty Empty = True
+  (==) (Snoc sx x) (Snoc sy y) = x == y && sx == sy
+  (==) _ _ = False
+
+
+public export
+Ord a => Ord (SnocList a) where
+  compare Empty Empty = EQ
+  compare Empty (Snoc sx x) = LT
+  compare (Snoc sx x) Empty = GT
+  compare (Snoc sx x) (Snoc sy y)
+    = case compare sx sy of
+        EQ => compare x y
+        c  => c
+
+public export
+(++) : (sx, sy : SnocList a) -> SnocList a
+(++) sx Empty = sx
+(++) sx (Snoc sy y) = Snoc (sx ++ sy) y
+
+public export
+length : SnocList a -> Nat
+length Empty = Z
+length (Snoc sx x) = length sx + 1
+
+public export
+Functor SnocList where
+  map f Empty = Empty
+  map f (Snoc sx x) = Snoc (map f sx) (f x)
+
+
+public export
+Semigroup (SnocList a) where
+  (<+>) = (++)
+
+public export
+Monoid (SnocList a) where
+  neutral = Empty
+
+
+||| Check if something is a member of a list using the default Boolean equality.
+public export
+elem : Eq a => a -> SnocList a -> Bool
+elem x Empty = False
+elem x (Snoc sx y) = x == y || elem x sx
+
+
+-- [ EOF ]

--- a/src/Katla.idr
+++ b/src/Katla.idr
@@ -69,14 +69,8 @@ escapeLatex '\\' = "\\textbackslash{}"
 escapeLatex '{'  = "\\{"
 escapeLatex '}'  = "\\}"
 escapeLatex x    = cast x
-      
-decoration : Maybe Decoration -> String
-decoration Nothing         = "black"
-decoration (Just Typ     ) = "DeepSkyBlue3"
-decoration (Just Function) = "Chartreuse4"
-decoration (Just Data    ) = "IndianRed1"
-decoration (Just Keyword ) = "Azure4"
-decoration (Just Bound   ) = "DarkOrchid3"
+
+
 
 annotate : Maybe Decoration -> String -> String
 annotate Nothing    s = s
@@ -96,7 +90,7 @@ annotate (Just dec) s = apply (convert dec) s
 color : String -> String
 color x = "\\color{\{x}}" -- String interpolation doesn't quite work yet
 
-{- Relies on the fact that PosMap is an efficient mapping from position: 
+{- Relies on the fact that PosMap is an efficient mapping from position:
 
 for each character in the file, find the tightest enclosing interval
 in PosMap and use its decoration.
@@ -124,8 +118,7 @@ engine : (input, output : File)
 engine input output posMap = engine Nothing
   where
     toString : SnocList String -> String
-    toString Empty = ""
-    toString (Snoc sx x) = toString sx <+> x
+    toString = (fastConcat . asList)
 
     snocEscape : SnocList String -> Char -> SnocList String
     snocEscape sx c = Snoc sx (escapeLatex c)
@@ -152,12 +145,12 @@ engine input output posMap = engine Nothing
     engine : Maybe Decoration -> (Int, Int) -> IO ()
     engine currentDecor currentPos
       = if !(fEOF input)
-      then pure ()
-      else do
-        Right str <- fGetLine input
-          | Left err => pure ()
-        (nextDecor, nextPos) <- processLine currentDecor currentPos (fastUnpack str) Empty
-        engine nextDecor nextPos
+        then pure ()
+        else do
+          Right str <- fGetLine input
+            | Left err => pure ()
+          (nextDecor, nextPos) <- processLine currentDecor currentPos (fastUnpack str) Empty
+          engine nextDecor nextPos
 
 main : IO ()
 main = do

--- a/src/Katla.idr
+++ b/src/Katla.idr
@@ -9,6 +9,45 @@ import Libraries.Data.PosMap
 import Data.List1
 import Data.List
 import Data.String
+import Data.SnocList
+
+laTeXHeader : String
+laTeXHeader =  """
+\newcommand{\IdrisHlightFont}         {\ttfamily}
+\newcommand{\IdrisHlightStyleData}    {}
+\newcommand{\IdrisHlightStyleType}    {}
+\newcommand{\IdrisHlightStyleBound}   {}
+\newcommand{\IdrisHlightStyleFunction}{}
+\newcommand{\IdrisHlightStyleKeyword} {\bfseries}
+\newcommand{\IdrisHlightStyleImplicit}{\itshape}
+\newcommand{\IdrisHlightStyleComment} {\itshape}
+\newcommand{\IdrisHlightStyleHole}    {\bfseries}
+
+\newcommand{\IdrisHlightColourData}    {IndianRed1}
+\newcommand{\IdrisHlightColourType}    {DeepSkyBlue3}
+\newcommand{\IdrisHlightColourBound}   {DarkOrchid3}
+\newcommand{\IdrisHlightColourFunction}{Chartreuse4}
+\newcommand{\IdrisHlightColourKeyword} {black}
+\newcommand{\IdrisHlightColourImplicit}{Darkorchid3}
+
+\newcommand{\IdrisHlightColourComment} {grey}
+\newcommand{\IdrisHlightColourHole}    {yellow}
+
+\newcommand{\IdrisHole}[1]{{%
+    \colorbox{yellow}{%
+      \IdrisHlightStyleHole\IdrisHlightFont%
+      #1}}}
+
+\newcommand{\RawIdrisHighlight}[3]{{\textcolor{#1}{#2\IdrisHlightFont#3}}}
+
+\newcommand{\IdrisData}[1]{\RawIdrisHighlight{\IdrisHlightColourData}{\IdrisHlightStyleData}{#1}}
+\newcommand{\IdrisType}[1]{\RawIdrisHighlight{\IdrisHlightColourType}{\IdrisHlightStyleType}{#1}}
+\newcommand{\IdrisBound}[1]{\RawIdrisHighlight{\IdrisHlightColourBound}{\IdrisHlightStyleBound}{#1}}
+\newcommand{\IdrisFunction}[1]{\RawIdrisHighlight{\IdrisHlightColourFunction}{\IdrisHlightStyleFunction}{#1}}
+\newcommand{\IdrisKeyword}[1]{\RawIdrisHighlight{\IdrisHlightColourKeyword}{\IdrisHlightStyleKeyword}{#1}}
+\newcommand{\IdrisImplicit}[1]{\RawIdrisHighlight{\IdrisHlightColourImplicit}{\IdrisHlightStyleImplicit}{#1}}
+\newcommand{\IdrisComment}[1]{\RawIdrisHighlight{\IdrisHlightColourComment}{\IdrisHlightStyleComment}{#1}}
+"""
 
 public export
 Eq Decoration where
@@ -39,6 +78,20 @@ decoration (Just Data    ) = "IndianRed1"
 decoration (Just Keyword ) = "Azure4"
 decoration (Just Bound   ) = "DarkOrchid3"
 
+annotate : Maybe Decoration -> String -> String
+annotate Nothing    s = s
+annotate (Just dec) s = apply (convert dec) s
+  where
+
+    convert : Decoration -> String
+    convert (Typ     ) = "IdrisType"
+    convert (Function) = "IdrisFunction"
+    convert (Data    ) = "IdrisData"
+    convert (Keyword ) = "IdrisKeyword"
+    convert (Bound   ) = "IdrisBound"
+
+    apply : String -> String -> String
+    apply f a = "\\\{f}{\{a}}"
 
 color : String -> String
 color x = "\\color{\{x}}" -- String interpolation doesn't quite work yet
@@ -51,7 +104,7 @@ in PosMap and use its decoration.
 
 pickSmallest : List1 ASemanticDecoration -> Decoration
 pickSmallest ((_, decor, _) ::: []) = decor
-pickSmallest (current ::: candidate :: ds) = 
+pickSmallest (current ::: candidate :: ds) =
   let endOf : ASemanticDecoration -> (Int, Int)
       endOf ((_, (_, end)), _, _) = end
   in if (endOf candidate < endOf current)
@@ -59,38 +112,53 @@ pickSmallest (current ::: candidate :: ds) =
      else pickSmallest (current   ::: ds)
 
 findDecoration : (Int, Int) -> PosMap ASemanticDecoration -> Maybe Decoration
-findDecoration pos@(row, col) posMap = 
+findDecoration pos@(row, col) posMap =
   case dominators ((row, col), (row, col+1)) posMap of
    []              => Nothing
    (d :: ds)       => Just $ pickSmallest (d ::: ds)
 
-engine : (input, output : File) -> PosMap ASemanticDecoration -> (Int, Int) -> IO ()
+engine : (input, output : File)
+       -> PosMap ASemanticDecoration
+       -> (Int, Int)
+       -> IO ()
 engine input output posMap = engine Nothing
   where
-    processLine : Maybe Decoration -> (Int, Int) -> List Char -> IO (Maybe Decoration, (Int, Int))
-    processLine currentDecor (currentRow, _) [] = do
-      let nextPos = (currentRow + 1, 0)
-      _ <- fPutStr output $ color (decoration currentDecor)
-      pure (currentDecor, nextPos)
-    processLine currentDecor currentPos@(currentRow, currentCol) (c :: rest) = 
-      let nextPos = (currentRow, currentCol + 1) 
-          decor   = findDecoration currentPos posMap in
-      if decor == currentDecor 
-      then do _ <- fPutStr output (escapeLatex c)
-              processLine currentDecor nextPos rest
-      else do _ <- fPutStr output $ color (decoration decor) ++ escapeLatex c
-              processLine decor        nextPos rest
-  
+    toString : SnocList String -> String
+    toString Empty = ""
+    toString (Snoc sx x) = toString sx <+> x
+
+    snocEscape : SnocList String -> Char -> SnocList String
+    snocEscape sx c = Snoc sx (escapeLatex c)
+
+    processLine : Maybe Decoration
+               -> (Int, Int)
+               -> List Char
+               -> SnocList String
+               -> IO (Maybe Decoration, (Int, Int))
+    processLine currentDecor (currentRow, _) [] stk
+      = do let nextPos = (currentRow + 1, 0)
+           _ <- fPutStr output (toString stk)
+           pure (currentDecor, nextPos)
+    processLine currentDecor currentPos@(currentRow, currentCol) (c :: rest) stk
+      = let nextPos = (currentRow, currentCol + 1)
+            decor   = findDecoration currentPos posMap
+        in if decor == currentDecor
+           then processLine currentDecor nextPos rest (snocEscape stk c)
+
+           else do let decorated = annotate currentDecor (toString stk)
+                   _ <- fPutStr output decorated
+                   processLine decor nextPos rest (snocEscape Empty c)
+
     engine : Maybe Decoration -> (Int, Int) -> IO ()
-    engine currentDecor currentPos 
+    engine currentDecor currentPos
       = if !(fEOF input)
       then pure ()
       else do
         Right str <- fGetLine input
           | Left err => pure ()
-        (nextDecor, nextPos) <- processLine currentDecor currentPos (fastUnpack str)
+        (nextDecor, nextPos) <- processLine currentDecor currentPos (fastUnpack str) Empty
         engine nextDecor nextPos
-    
+
 main : IO ()
 main = do
   putStrLn "Katla v0.1"
@@ -100,7 +168,7 @@ main = do
                       (const $ pure Nothing)
                       pure
     | Nothing => putStrLn "Couldn't open metadata"
-  
+
   Right fout <- openFile "temp/Katla.tex" WriteTruncate
     | Left err => putStrLn "couldn't open output"
 

--- a/temp/Example.tex
+++ b/temp/Example.tex
@@ -3,6 +3,41 @@
 \usepackage{fancyvrb}
 \usepackage[x11names]{xcolor}
 
+\newcommand{\IdrisHlightFont}         {\ttfamily}
+\newcommand{\IdrisHlightStyleData}    {}
+\newcommand{\IdrisHlightStyleType}    {}
+\newcommand{\IdrisHlightStyleBound}   {}
+\newcommand{\IdrisHlightStyleFunction}{}
+\newcommand{\IdrisHlightStyleKeyword} {\bfseries}
+\newcommand{\IdrisHlightStyleImplicit}{\itshape}
+\newcommand{\IdrisHlightStyleComment} {\itshape}
+\newcommand{\IdrisHlightStyleHole}    {\bfseries}
+
+\newcommand{\IdrisHlightColourData}    {IndianRed1}
+\newcommand{\IdrisHlightColourType}    {DeepSkyBlue3}
+\newcommand{\IdrisHlightColourBound}   {DarkOrchid3}
+\newcommand{\IdrisHlightColourFunction}{Chartreuse4}
+\newcommand{\IdrisHlightColourKeyword} {black}
+\newcommand{\IdrisHlightColourImplicit}{Darkorchid3}
+
+\newcommand{\IdrisHlightColourComment} {grey}
+\newcommand{\IdrisHlightColourHole}    {yellow}
+
+\newcommand{\IdrisHole}[1]{{%
+    \colorbox{yellow}{%
+      \IdrisHlightStyleHole\IdrisHlightFont%
+      #1}}}
+
+\newcommand{\RawIdrisHighlight}[3]{{\textcolor{#1}{#2\IdrisHlightFont#3}}}
+
+\newcommand{\IdrisData}[1]{\RawIdrisHighlight{\IdrisHlightColourData}{\IdrisHlightStyleData}{#1}}
+\newcommand{\IdrisType}[1]{\RawIdrisHighlight{\IdrisHlightColourType}{\IdrisHlightStyleType}{#1}}
+\newcommand{\IdrisBound}[1]{\RawIdrisHighlight{\IdrisHlightColourBound}{\IdrisHlightStyleBound}{#1}}
+\newcommand{\IdrisFunction}[1]{\RawIdrisHighlight{\IdrisHlightColourFunction}{\IdrisHlightStyleFunction}{#1}}
+\newcommand{\IdrisKeyword}[1]{\RawIdrisHighlight{\IdrisHlightColourKeyword}{\IdrisHlightStyleKeyword}{#1}}
+\newcommand{\IdrisImplicit}[1]{\RawIdrisHighlight{\IdrisHlightColourImplicit}{\IdrisHlightStyleImplicit}{#1}}
+\newcommand{\IdrisComment}[1]{\RawIdrisHighlight{\IdrisHlightColourComment}{\IdrisHlightStyleComment}{#1}}
+
 \begin{document}
 \VerbatimInput[commandchars=\\\{\}]{temp/Katla.tex}
 \end{document}


### PR DESCRIPTION
This brings Katla in line with Idris1's LaTeX output.
Each annotated term is highlighted with a custom command.
The preamble presents the *default* styling information, which can be overridden by users more easily.